### PR TITLE
Fix examples and doctests

### DIFF
--- a/src/combine.rs
+++ b/src/combine.rs
@@ -46,7 +46,7 @@ pub fn index(size: usize, combine_len: usize) -> Vec<Vec<usize>> {
 /// * for example
 /// ``` rust
 /// use combination::*;
-/// let val = combine(&vec![10, 20, 30, 40], 2);
+/// let val = combine::from_vec_at(&vec![10, 20, 30, 40], 2);
 /// for item in val {
 ///     println!("{:?}", item);
 /// }
@@ -54,13 +54,14 @@ pub fn index(size: usize, combine_len: usize) -> Vec<Vec<usize>> {
 ///
 /// * and will get:
 ///
+/// ```
 /// [10, 20]
 /// [10, 30]
 /// [10, 40]
 /// [20, 30]
 /// [20, 40]
 /// [30, 40]
-///
+/// ```
 pub fn from_vec_at<T: Clone>(tgt: &Vec<T>, size: usize) -> Vec<Vec<T>> {
     let mut res: Vec<Vec<T>> = Vec::new();
     let temp = index(tgt.len(), size);
@@ -76,7 +77,7 @@ pub fn from_vec_at<T: Clone>(tgt: &Vec<T>, size: usize) -> Vec<Vec<T>> {
 /// * for example
 /// ``` rust
 /// use combination::*;
-/// let val = combine_all(&vec![10, 20, 30]);
+/// let val = combine::from_vec(&vec![10, 20, 30]);
 /// for item in val {
 ///     println!("{:?}", item);
 /// }
@@ -84,13 +85,15 @@ pub fn from_vec_at<T: Clone>(tgt: &Vec<T>, size: usize) -> Vec<Vec<T>> {
 ///
 /// * and will get:
 ///
+/// ```
 /// [10]
 /// [20]
 /// [30]
 /// [10, 20]
 /// [10, 30]
 /// [20, 30]
-/// [10,20, 30]
+/// [10, 20, 30]
+/// ```
 pub fn from_vec<T: Clone>(list: &Vec<T>) -> Vec<Vec<T>> {
     let mut res: Vec<Vec<T>> = Vec::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! ```rust
 //! use combination::*;
 //! fn test_permutation() {
-//!     let val = permutate(&vec![10, 20, 30, 40]);
+//!     let val = permutate::from_vec(&vec![10, 20, 30, 40]);
 //!     for item in val {
 //!        println!("{:?}", item);
 //!     }

--- a/src/permutate.rs
+++ b/src/permutate.rs
@@ -33,7 +33,7 @@ pub fn index(size: usize) -> Vec<Vec<usize>> {
 /// * for example
 /// ``` rust
 /// use combination::*;
-/// let val = permutate(&vec![10, 20, 30, 40]);
+/// let val = permutate::from_vec(&vec![10, 20, 30, 40]);
 /// for item in val {
 ///     println!("{:?}", item);
 /// }
@@ -41,7 +41,9 @@ pub fn index(size: usize) -> Vec<Vec<usize>> {
 ///
 /// * and will get:
 ///
-///
+/// ```
+/// [40, 30, 10, 20]
+/// [30, 40, 10, 20]
 /// [30, 10, 40, 20]
 /// [30, 10, 20, 40]
 /// [40, 10, 30, 20]
@@ -64,7 +66,7 @@ pub fn index(size: usize) -> Vec<Vec<usize>> {
 /// [20, 40, 10, 30]
 /// [20, 10, 40, 30]
 /// [20, 10, 30, 40]
-///
+/// ```
 
 pub fn from_vec<T: Clone>(tgt: &Vec<T>) -> Vec<Vec<T>> {
     let mut res: Vec<Vec<T>> = Vec::new();


### PR DESCRIPTION
- Add missing output for `permutate`.
- Need to use `from_vec`.
- Manually checked the other example outputs.
- Show output lines in code blocks so each output appears on a separate line.

Preview: https://celehner.com/2022/01/01/doc/combination/permutate/fn.from_vec.html  
Compare to: https://docs.rs/combination/0.1.5/combination/permutate/fn.from_vec.html